### PR TITLE
register.css

### DIFF
--- a/public/css/register.css
+++ b/public/css/register.css
@@ -1,0 +1,44 @@
+body {
+	font-family: Arial, sans-serif;
+	background-color: #f4f4f4;
+	margin: 0;
+	padding: 0;
+	height: 100vh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+  }
+  
+  .container {
+	background-color: #fff;
+	padding: 20px;
+	border-radius: 5px;
+	box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.1);
+  }
+  
+  form div {
+	margin-bottom: 15px;
+  }
+  
+  input[type="text"], input[type="password"] {
+	width: 100%;
+	padding: 10px;
+	border: 1px solid #ddd;
+	border-radius: 5px;
+	font-size: 16px;
+  }
+  
+  input[type="submit"] {
+	background-color: #5C6BC0;
+	color: #fff;
+	border: none;
+	border-radius: 5px;
+	padding: 10px 15px;
+	font-size: 16px;
+	cursor: pointer;
+  }
+  
+  input[type="submit"]:hover {
+	background-color: #3949AB;
+  }
+  


### PR DESCRIPTION
This pull request introduces a new CSS file, `public/css/register.css`, which defines the styling for a registration page. The changes include defining the font, background color, and layout for the body of the page, as well as specific styles for the form container, form divs, text and password inputs, and submit button. The submit button also has a hover effect.

Here are the key changes:

* [`public/css/register.css`](diffhunk://#diff-1c5ce50a1a671c3864fb64d8a04b3ab44c120481f4d7bab6bf545ab0ea8c037fR1-R44): Added new CSS file with styles for the body, form container, form divs, text and password inputs, and submit button. The body has been styled to use the Arial font, a light grey background color, and a flex layout to center its content. The form container has a white background, padding, rounded corners, and a subtle box shadow. The form divs have a margin at the bottom. The text and password inputs are styled to take up the full width, have padding and a border, rounded corners, and a larger font size. The submit button is styled with a blue background, white text, no border, padding, a larger font size, and a cursor pointer. It also has a hover effect that changes the background color.